### PR TITLE
Consolidated K8s/OpenShift deployments and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# CrowdStrike Falcon Linux Sensor Detection Test Container
+# CrowdStrike Falcon Linux Detection Container
 
-## ⚠️ Disclaimer
-This is a community project and is not officially supported or affiliated with CrowdStrike. It is provided "as is" without warranty of any kind.
+## ⚠️ Disclaimer and Risk Notice
+This project is a community-developed tool and is **NOT** officially supported by CrowdStrike. Use at your own risk. While the container performs benign simulations, you should:
+- Review all code before running in your environment
+- Understand that this may generate security alerts in your environment
+- Be aware that running security test tools may violate some organizations' security policies
 
 ## Overview
-This container provides a safe, controlled environment for validating CrowdStrike Falcon Linux sensor detections. It generates various detection patterns to help confirm proper sensor deployment and configuration. All tests run as a non-root user, demonstrating CrowdStrike's ability to detect malicious behavior regardless of privilege level.
+This container provides a safe, controlled environment for validating CrowdStrike Falcon Linux sensor detections across Docker, Kubernetes, and OpenShift environments. It generates various detection patterns to help confirm proper sensor deployment and configuration.
 
 ### Detection Scenarios
 The container runs through the following detection scenarios:
 
 1. **File Masquerading Tests**
-   - Simulates malware attempting to masquerade as legitimate documents
+   - Simulates malware attempting to masquerading as legitimate documents
    - Tests multiple file extensions and execution patterns
    - Generates Defense Evasion detections
 
@@ -25,40 +28,36 @@ The container runs through the following detection scenarios:
    - Generates cryptocurrency mining detections
 
 ## Prerequisites
-
-- Docker installed and running
-- CrowdStrike Falcon sensor installed and running
-- Falcon sensor policies configured for:
+- CrowdStrike Falcon sensor installed
+- Falcon policies configured for:
   - Detection-only mode (not Prevention)
   - Enhanced Visibility enabled
   - Sensor Visibility enabled
 
-## Usage
-
-### 1. Clone the Repository
+## Docker Deployment
 ```bash
-git clone https://github.com/your-username/linux-detection-container.git
-cd linux-detection-container
+docker build -t detection-test .
+docker run --rm detection-test
 ```
 
-### 2. Build the Container
+## Kubernetes/OpenShift Deployment
+For Kubernetes:
 ```bash
-docker build -t edr-test .
+kubectl create -f https://raw.githubusercontent.com/kuhnskc/linux-detection-container/main/deployments/job.yaml
+```
+```bash
+kubectl logs -f job/detection-test
 ```
 
-### 3. Run the Container
+## For OpenShift:
 ```bash
-docker run --name detection-test edr-test
+oc create -f https://raw.githubusercontent.com/kuhnskc/linux-detection-container/main/deployments/job.yaml
+```
+```bash
+oc logs -f job/detection-test
 ```
 
-### What to Expect
-- The container will run through two iterations of tests
-- Each iteration includes file masquerading, credential collection, and cryptocurrency mining simulations
-- Total runtime is approximately 3-4 minutes
-- All activities are benign simulations - no systems will be harmed
-- All tests run as non-root user
-
-### Expected Detections
+## Expected Detections
 After running the container, check your Falcon console for:
 1. Multiple file masquerading detections (Defense Evasion)
 2. Credential access attempts (Collection)
@@ -70,16 +69,4 @@ After running the container, check your Falcon console for:
 - Tests run automatically and require no user interaction
 - Container automatically stops after completing all tests
 - All tests execute with non-root privileges
-
-## Troubleshooting
-If you don't see detections:
-1. Verify the Falcon sensor is running: `sudo falcon-sensor-version`
-2. Confirm policy settings are in detection-only mode
-3. Ensure Enhanced Visibility is enabled
-4. Check that Sensor Visibility is enabled
-
-## Contributing
-Contributions are welcome! Please feel free to submit pull requests or create issues for bugs and feature requests.
-
-## License
-[MIT License](LICENSE)
+- Container is multi-architecture (supports both AMD64 and ARM64)

--- a/deployments/job.yaml
+++ b/deployments/job.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: detection-test
+spec:
+  ttlSecondsAfterFinished: 100
+  template:
+    spec:
+      containers:
+      - name: detection-test
+        image: kckuhns92/openshift-detection-container:latest
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1001
+          seccompProfile:
+            type: RuntimeDefault
+      restartPolicy: Never


### PR DESCRIPTION
Consolidated Kubernetes and OpenShift Deployments

Changes made:
- Consolidated duplicate Kubernetes and OpenShift job.yaml files into a single deployment file
- Simplified directory structure from separate k8s/openshift folders to single deployments folder
- Updated README with:
  - Clearer deployment instructions
  - Direct links to raw job.yaml file
  - Separate code blocks for better copy/paste
  - Combined K8s/OpenShift section since deployment is identical
- Removed unnecessary setup/troubleshooting instructions
- Added stronger disclaimer about community tool usage

The container now supports:
- Direct Docker execution
- Kubernetes deployment
- OpenShift deployment

All using the same container image and deployment configuration.
